### PR TITLE
adding customTpl to eval

### DIFF
--- a/docs/dev/reference/dca/fields.md
+++ b/docs/dev/reference/dca/fields.md
@@ -137,6 +137,7 @@ Each field can be validated against a regular expression.
 | cols               | Columns (`integer`)              | Number of columns (used for `textarea`, `radioTable` and `tableWizard` fields).                                                                                                                                |
 | csv                | Delimiter (`string`)             | The choice of this field will not be stored as serialized string but rather as given delimiter-separated list. Example: `'eval' => ['csv'=>',']`                 |
 | customRgxp        | Regular expression (`string`) | {{< version "4.11" >}} Custom regular expression to be used when using `'rgxp' => 'custom'` |
+| customTpl        | Filename (`string`) | Use own template for this input field `'customTpl' => 'template-file-name'` |
 | datepicker         | true/false (`bool`)           | If true the current field will have a [MooTools-DatePicker](https://github.com/arian/mootools-datepicker).                                                                                                                             |
 | dcaPicker          | true/false (`bool`)           | If true the general purpose picker will be shown. Allows to pick different records from the system and return them as an insert tag.                                     |
 | decodeEntities     | true/false (`bool`)           | If true HTML entities will be decoded. Note that HTML entities are always decoded if allowHtml is true.                                                                  |


### PR DESCRIPTION
If you want to use a custom template for your input field, the hint in the dev-doc is missing